### PR TITLE
Make ALSA support work

### DIFF
--- a/src/widget/volume/alsa.rs
+++ b/src/widget/volume/alsa.rs
@@ -77,6 +77,6 @@ impl<F> VolumeBackend<F> for ALSA
     }
 }
 
-pub fn default_volume() -> FreeBSDSound {
+pub fn default_volume() -> ALSA {
     ALSA::new()
 }

--- a/src/widget/volume/alsa.rs
+++ b/src/widget/volume/alsa.rs
@@ -54,6 +54,12 @@ impl<F> VolumeBackend<F> for ALSA
         let filled = ctl.fill(&mut fds).unwrap();
         assert!(filled == ctl.count());
 
+        let initial_state = ALSA::get_volume_state();
+        {
+            let mut writer = self.last_value.write().unwrap();
+            *writer = (*updater)(initial_state);
+        }
+
         let last_value = self.last_value.clone();
         thread::spawn(move || {
             loop {


### PR DESCRIPTION
There was an incorrect return type in `default_volume`, probably from a copypaste error. I've also made the code fetch an initial value for the volume, so that it doesn't sit there at "" until something changes.